### PR TITLE
[Add]Taskモデルのバリデーションチェックのテストを実装

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :task do
-    
+
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :task do
-
+    sequence(:title) { |n| "タイトル#{n}" }
+    content { "内容" }
+    status { :todo }
+    deadline { 1.week.from_now }
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,5 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+
+  it 'titleとstatusが存在すれば有効であること' do
+    task = Task.new(title: 'タイトル', status: :doing)
+    expect(task).to be_valid
+  end
+
+  it 'titleが存在しない場合無効であること' do
+    task = FactoryBot.build(:task, title: nil)
+    task.valid?
+    expect(task.errors[:title]).to include("can't be blank")
+  end
+
+  it 'statusが存在しない場合無効であること' do
+    task = FactoryBot.build(:task, status: nil)
+    task.valid?
+    expect(task.errors[:status]).to include("can't be blank")
+  end
+
+  it 'titleが重複する場合無効であること' do
+    task = FactoryBot.create(:task, title: 'タイトル')
+    task2 = FactoryBot.build(:task, title: 'タイトル')
+    task2.valid?
+    expect(task2.errors[:title]).to include('has already been taken')
+  end
+
+  it 'titleが重複しない場合有効であること' do
+    task = FactoryBot.create(:task, title: 'タイトル')
+    task2 = FactoryBot.build(:task, title: 'タイトル2')
+    task2.valid?
+    expect(task2).to be_valid
+  end
 end


### PR DESCRIPTION
Taskモデルのバリデーション機能のテストを作成しました。
レビューよろしくお願いします。

## 実装の概要
 - titleとstatusが両方存在する場合に、Taskモデルのオブジェクトが有効となることをテスト。
 - title、statusの存在性チェックをテスト
 - titleのユニーク性チェックをテスト
   - titleが重複する場合としない場合の2ケースでテスト

- FactoryBotを用いてTaskモデルのデータを作成。
 - FactoryBotで複数のデータを作成した時に、titleの値が重複しないようにシーケンスを使用。

- rspec ファイルに `--format documentation`を追記。