### PR TITLE
[Fix]Taskモデルのバリデーションチェックのテストを修正

### DIFF
--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -8,28 +8,24 @@ RSpec.describe Task, type: :model do
   end
 
   it 'titleが存在しない場合無効であること' do
-    task = FactoryBot.build(:task, title: nil)
-    task.valid?
-    expect(task.errors[:title]).to include("can't be blank")
+    task = build(:task, title: nil)
+    expect(task).to be_invalid
   end
 
   it 'statusが存在しない場合無効であること' do
-    task = FactoryBot.build(:task, status: nil)
-    task.valid?
-    expect(task.errors[:status]).to include("can't be blank")
+    task = build(:task, status: nil)
+    expect(task).to be_invalid
   end
 
   it 'titleが重複する場合無効であること' do
-    task = FactoryBot.create(:task, title: 'タイトル')
-    task2 = FactoryBot.build(:task, title: 'タイトル')
-    task2.valid?
-    expect(task2.errors[:title]).to include('has already been taken')
+    task = create(:task, title: 'タイトル')
+    other_task = build(:task, title: 'タイトル')
+    expect(other_task).to be_invalid
   end
 
   it 'titleが重複しない場合有効であること' do
-    task = FactoryBot.create(:task, title: 'タイトル')
-    task2 = FactoryBot.build(:task, title: 'タイトル2')
-    task2.valid?
-    expect(task2).to be_valid
+    task = create(:task, title: 'タイトル')
+    other_task = build(:task, title: 'タイトル2')
+    expect(other_task).to be_valid
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -10,17 +10,20 @@ RSpec.describe Task, type: :model do
   it 'titleが存在しない場合無効であること' do
     task = build(:task, title: nil)
     expect(task).to be_invalid
+    expect(task.errors[:title]).to include("can't be blank")
   end
 
   it 'statusが存在しない場合無効であること' do
     task = build(:task, status: nil)
     expect(task).to be_invalid
+    expect(task.errors[:status]).to include("can't be blank")
   end
 
   it 'titleが重複する場合無効であること' do
     task = create(:task, title: 'タイトル')
     other_task = build(:task, title: 'タイトル')
     expect(other_task).to be_invalid
+    expect(other_task.errors[:title]).to include('has already been taken')
   end
 
   it 'titleが重複しない場合有効であること' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,4 +61,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # 各テストコードから、FactoryBotという記述を省略可能にする
+  config.include FactoryBot::Syntax::Methods
 end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,3 +1,0 @@
-RSpec.configure do |config|
-  config.include FactoryBot::Syntax::Methods
-end


### PR DESCRIPTION
Taskモデルのバリデーションチェックのテストを修正しました。
設定ファイルの記述が少し不安ですが、ご確認いただければと思います。

**【設定ファイルの追記】**
1. `spec/support`配下のRSpec設定ファイルを読み込めるよう、`spec/rails_helper.rb`の一部コメントアウトを外す。
2. 新しく作成した`spec/support/factory_bot.rb`の設定により、各テストコードの`FactoryBot`という記述を省略可能にする。

（※もしくは、RSpecの設定は、`spec/rails_helper.rb`ファイルに全て纏めた方が良い？）

**【テストコード】**
- `task2`を`other_task`に変更。
- `valid?`は使用せずに、`be_valid`マッチャ、`be_invalid`マッチャにまとめる。

**【テスト実行時のキャプチャ】**
<img width="676" alt="スクリーンショット 2020-05-04 13 13 47" src="https://user-images.githubusercontent.com/60560627/80935758-18ca9180-8e09-11ea-89a3-9071e3abbea5.png">